### PR TITLE
Fix wrong image shown in docs

### DIFF
--- a/docs/classes/understat.rst
+++ b/docs/classes/understat.rst
@@ -603,7 +603,7 @@ which outputs (with parts omitted)
 It returns the information about the matches played by the given player. So for
 example, the matches Sergio Agüero has played, as seen in the screenshot
 
-.. image:: https://i.imgur.com/dE54ox0.png
+.. image:: https://i.imgur.com/p7jh1mh.png
 
 This function also comes with the `options` keyword argument, and also the
 `**kwargs` magic variable. An example of how you could


### PR DESCRIPTION
Currently, where a player's matches should be shown in the Understat.get_player_matches() method, it shows the fixtures for a gameweek.