### PR TITLE
Get league table with date filters

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -7,3 +7,4 @@ Contributors
 ````````````
 
 - Chris Musson <chris.musson@hotmail.com> `@ChrisMusson <https://github.com/ChrisMusson>`_
+- Gracjan Strzelec <gracjanss98@gmail.com> `@gracjans <https://github.com/gracjans>`_

--- a/docs/classes/understat.rst
+++ b/docs/classes/understat.rst
@@ -148,6 +148,11 @@ It returns the standings of the given league in the given year, as seen in the s
 
 .. image:: https://i.imgur.com/fYo9zkz.png
 
+There are also optional "start_date" and "end_date=None" arguments,
+which can be used to get the table for a specific date range from given season, like on screenshot below
+
+.. image:: https://i.imgur.com/r30bdpn.png
+
 An example of getting the standings from the EPL in 2019 can be found below
 
 .. code-block:: python

--- a/docs/classes/understat.rst
+++ b/docs/classes/understat.rst
@@ -148,8 +148,8 @@ It returns the standings of the given league in the given year, as seen in the s
 
 .. image:: https://i.imgur.com/fYo9zkz.png
 
-There are also optional "start_date" and "end_date=None" arguments,
-which can be used to get the table for a specific date range from given season, like on screenshot below
+There are also optional "start_date" and "end_date" arguments,
+which can be used to get the table from a specific date range from given season, like on screenshot below
 
 .. image:: https://i.imgur.com/r30bdpn.png
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="understat",
-    version="0.1.3",
+    version="0.1.4",
     packages=find_packages(),
     description="A Python wrapper for https://understat.com/",
     long_description=long_description,

--- a/tests/test_understat.py
+++ b/tests/test_understat.py
@@ -117,6 +117,10 @@ class TestUnderstat(object):
         table = await understat.get_league_table("epl", 2020)
         assert isinstance(table, list)
 
+    async def test_get_league_table_with_date(self, loop, understat):
+        table = await understat.get_league_table("epl", 2020, start_date="2019-11-01", end_date="2020-01-31")
+        assert isinstance(table, list)
+
     async def test_get_player_shots(self, loop, understat):
         player_shots = await understat.get_player_shots(619)
         assert isinstance(player_shots, list)

--- a/tests/test_understat.py
+++ b/tests/test_understat.py
@@ -118,7 +118,7 @@ class TestUnderstat(object):
         assert isinstance(table, list)
 
     async def test_get_league_table_with_date(self, loop, understat):
-        table = await understat.get_league_table("epl", 2020, start_date="2019-11-01", end_date="2020-01-31")
+        table = await understat.get_league_table("epl", 2020, start_date="2020-11-01", end_date="2021-01-31")
         assert isinstance(table, list)
 
     async def test_get_player_shots(self, loop, understat):

--- a/understat/understat.py
+++ b/understat/understat.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from understat.constants import (BASE_URL, LEAGUE_URL, MATCH_URL, PLAYER_URL,
                                  TEAM_URL)
 from understat.utils import (filter_by_positions, filter_data, get_data,

--- a/understat/understat.py
+++ b/understat/understat.py
@@ -170,8 +170,8 @@ class Understat():
             o_def_act = sum(x["ppda_allowed"]["def"] for x in season_stats)
 
             # insert PPDA and OPPDA so they match with the positions in the table on the website
-            team_data.insert(-3, round(0 if passes == 0 else (passes / def_act), 2))
-            team_data.insert(-3, round(0 if o_passes == 0 else (o_passes / o_def_act), 2))
+            team_data.insert(-3, round(0 if def_act == 0 else (passes / def_act), 2))
+            team_data.insert(-3, round(0 if o_def_act == 0 else (o_passes / o_def_act), 2))
 
             data.append(team_data)
 

--- a/understat/understat.py
+++ b/understat/understat.py
@@ -158,7 +158,7 @@ class Understat():
             team_data = []
             season_stats = stats[team_id]["history"]
             if start_date is not None or end_date is not None:
-                season_stats = filter_by_date(season_stats, start_date, end_date, season)
+                season_stats = filter_by_date(season_stats, season, start_date, end_date)
             team_data.append(stats[team_id]["title"])
             team_data.append(len(season_stats))
             team_data.extend([round(sum(x[key] for x in season_stats), 2) for key in keys])

--- a/understat/understat.py
+++ b/understat/understat.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from understat.constants import (BASE_URL, LEAGUE_URL, MATCH_URL, PLAYER_URL,
                                  TEAM_URL)
 from understat.utils import (filter_by_positions, filter_data, get_data,
-                             to_league_name)
+                             to_league_name, filter_by_date)
 
 
 class Understat():
@@ -155,13 +155,12 @@ class Understat():
                 "deep", "deep_allowed", "xpts"]
         team_ids = [x for x in stats]
 
-        start_date = datetime.strptime(start_date, "%Y-%m-%d") if start_date else datetime(int(season), 1, 1)
-        end_date = datetime.strptime(end_date, "%Y-%m-%d") if end_date else datetime.today()
-
         data = []
         for team_id in team_ids:
             team_data = []
-            season_stats = list(filter(lambda x: start_date <= datetime.strptime(x["date"].split()[0], "%Y-%m-%d") <= end_date, stats[team_id]["history"]))
+            season_stats = stats[team_id]["history"]
+            if start_date is not None or end_date is not None:
+                season_stats = filter_by_date(season_stats, start_date, end_date, season)
             team_data.append(stats[team_id]["title"])
             team_data.append(len(season_stats))
             team_data.extend([round(sum(x[key] for x in season_stats), 2) for key in keys])

--- a/understat/utils.py
+++ b/understat/utils.py
@@ -86,7 +86,7 @@ def filter_by_positions(data, positions):
     return relevant_stats
 
 
-def filter_by_date(data, start, end, season):
+def filter_by_date(data, season, start, end):
     """Filter data by start and end date."""
 
     # change strings to datetime if specified, otherwise get full season time span

--- a/understat/utils.py
+++ b/understat/utils.py
@@ -1,6 +1,7 @@
 import codecs
 import json
 import re
+from datetime import datetime
 
 from bs4 import BeautifulSoup
 
@@ -83,3 +84,17 @@ def filter_by_positions(data, positions):
             relevant_stats.append(stats)
 
     return relevant_stats
+
+
+def filter_by_date(data, start, end, season):
+    """Filter data by start and end date."""
+
+    # change strings to datetime if specified, otherwise get full season time span
+    try:
+        start = datetime.strptime(start, "%Y-%m-%d") if start is not None else datetime(int(season), 1, 1)
+        end = datetime.strptime(end, "%Y-%m-%d") if end is not None else datetime(int(season) + 2, 1, 1)
+
+        return list(filter(lambda x: start <= datetime.strptime(x["date"].split()[0], "%Y-%m-%d") <= end, data))
+
+    except ValueError:
+        raise ValueError("Invalid date format. Please use YYYY-MM-DD.")


### PR DESCRIPTION
I'm creating AI-based bot to play FPL ([link](https://github.com/gracjans/FPL_AI_manager)) and would like to use Your package to scrape some Understat data. I need to to get league table and clubs stats from specific time period, just like it can be done on Understat website (screen below). Unfortunately, this couldn't be done with this open-source package, but I implemented it for myself. 

Perhaps this will be useful to others (I also think that filtering by date can be added to other functions, but for now I focused strictly on the get_league_table method). 

I tried to follow all the guidelines (PEP8, implemented test, updated docs) but I'm still learning (it's my first open-source contribution) so if You have any concerns or remarks, don't hesitate to point them out. Also if You have any questions, I'm open to discussion.

![image](https://user-images.githubusercontent.com/77151129/180325434-9907adaf-0b93-4984-9def-f790d137ed1c.png)

![image](https://user-images.githubusercontent.com/77151129/180331412-e2cc2e93-c67e-4771-a33c-ba49370969ae.png)