### PR TITLE
Update beautifulsoup4 to 4.12.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "Source": "https://github.com/amosbastian/fpl"
     },
     install_requires=[
-        "beautifulsoup4==4.11.1",
+        "beautifulsoup4==4.12.3",
         "pytest-aiohttp==1.0.4",
         "pytest-cov==4.0.0",
         "pytest-mock==3.6.0",


### PR DESCRIPTION
`File "/root/.local/share/virtualenvs/StatsWizardBot-7dc8CGLW/lib/python3.11/site-packages/pandas/io/html.py", line 971, in _parse
    parser = _parser_dispatch(flav)
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/virtualenvs/StatsWizardBot-7dc8CGLW/lib/python3.11/site-packages/pandas/io/html.py", line 916, in _parser_dispatch
    import_optional_dependency("bs4")
  File "/root/.local/share/virtualenvs/StatsWizardBot-7dc8CGLW/lib/python3.11/site-packages/pandas/compat/_optional.py", line 164, in import_optional_dependency
    raise ImportError(msg)
ImportError: Pandas requires version '4.11.2' or newer of 'bs4' (version '4.11.1' currently installed).`